### PR TITLE
Api capture list

### DIFF
--- a/lib/app_web/controllers/captures_controller.ex
+++ b/lib/app_web/controllers/captures_controller.ex
@@ -20,4 +20,20 @@ defmodule AppWeb.CaptureController do
         render(conn, "new.html", changeset: changeset)
     end
   end
+
+  def api_create(conn, %{"text" => capture}) do
+    case Ctx.create_item(%{text: capture}) do
+      {:ok, item} ->
+        render(conn, "capture.json", item: %{text: item.text})
+
+      {:error, _} ->
+        error = %{error: "The capture cannot be saved."}
+        render(conn, "capture_error.json", err: error)
+    end
+  end
+
+  def api_create(conn, _params) do
+    error = %{error: "text field is not defined"}
+    render(conn, "capture_error.json", err: error)
+  end
 end

--- a/lib/app_web/controllers/item_controller.ex
+++ b/lib/app_web/controllers/item_controller.ex
@@ -9,6 +9,11 @@ defmodule AppWeb.ItemController do
     render(conn, "index.html", items: items)
   end
 
+  def api_index(conn, _params) do
+    items = Ctx.list_items()
+    render(conn, "index.json", items: items)
+  end
+
   def new(conn, _params) do
     changeset = Ctx.change_item(%Item{})
     render(conn, "new.html", changeset: changeset)

--- a/lib/app_web/router.ex
+++ b/lib/app_web/router.ex
@@ -51,8 +51,8 @@ defmodule AppWeb.Router do
 
   # Other scopes may use custom stacks.
   scope "/api", AppWeb do
-     pipe_through :api
+    pipe_through :api
 
-     post "/capture", CaptureController, :api_create
-   end
+    post "/capture", CaptureController, :api_create
+  end
 end

--- a/lib/app_web/router.ex
+++ b/lib/app_web/router.ex
@@ -50,7 +50,9 @@ defmodule AppWeb.Router do
   end
 
   # Other scopes may use custom stacks.
-  # scope "/api", AppWeb do
-  #   pipe_through :api
-  # end
+  scope "/api", AppWeb do
+     pipe_through :api
+
+     post "/capture", CaptureController, :api_create
+   end
 end

--- a/lib/app_web/router.ex
+++ b/lib/app_web/router.ex
@@ -53,6 +53,7 @@ defmodule AppWeb.Router do
   scope "/api", AppWeb do
     pipe_through :api
 
-    post "/capture", CaptureController, :api_create
+    post "/captures/create", CaptureController, :api_create
+    get "/items", ItemController, :api_index
   end
 end

--- a/lib/app_web/views/capture_view.ex
+++ b/lib/app_web/views/capture_view.ex
@@ -1,3 +1,11 @@
 defmodule AppWeb.CaptureView do
   use AppWeb, :view
+
+  def render("capture.json", data) do
+    data.item
+  end
+
+  def render("capture_error.json", data) do
+    data.err
+  end
 end

--- a/lib/app_web/views/item_view.ex
+++ b/lib/app_web/views/item_view.ex
@@ -1,3 +1,7 @@
 defmodule AppWeb.ItemView do
   use AppWeb, :view
+
+  def render("index.json", data) do
+    Enum.map(data.items, fn i -> %{id: i.id, text: i.text} end)
+  end
 end

--- a/test/app_web/controllers/capture_controller_test.exs
+++ b/test/app_web/controllers/capture_controller_test.exs
@@ -22,6 +22,12 @@ defmodule AppWeb.CaptureControllerTest do
       assert redirected_to(conn) == Routes.categorise_path(conn, :index)
     end
 
+
+    test "api - create a new capture", %{conn: conn} do
+      conn = post(conn, Routes.capture_path(conn, :api_create), item: @create_attrs)
+      assert json_response(conn, 200)
+    end
+
     test "renders errors when data is invalid", %{conn: conn} do
       conn =
         post(conn, Routes.capture_path(conn, :create), item: @invalid_attrs)

--- a/test/app_web/controllers/item_controller_test.exs
+++ b/test/app_web/controllers/item_controller_test.exs
@@ -19,6 +19,11 @@ defmodule AppWeb.ItemControllerTest do
       conn = get(conn, Routes.item_path(conn, :index))
       assert html_response(conn, 200) =~ "Listing Items"
     end
+
+    test "api - lists all items", %{conn: conn} do
+      conn = get(conn, Routes.item_path(conn, :api_index))
+      assert json_response(conn, 200)
+    end
   end
 
   describe "new item" do


### PR DESCRIPTION
ref: #53
Capture api endpoint.
To test you can run the sever as usual with `mix phx.sever` then run the following curl command:
```sh
curl --data "text=api capture test" localhost:4000/api/capture
```

The `text` field needs to be defined, otherwise the capture won't be saved and an error message is returned in a json format

- [x] Need to add a test for this endpoint

